### PR TITLE
Make frontend staging message more unobtrusive

### DIFF
--- a/Views/frontend/plugins/k10r_staging/notice.tpl
+++ b/Views/frontend/plugins/k10r_staging/notice.tpl
@@ -1,5 +1,5 @@
 {block name='frontend_k10r_staging_notice'}
-    <div style="position: absolute; top: 0; width: 100%;">
+    <div style="position: fixed; top: 0; width: 25%; right: 0">
         {include file='frontend/_includes/messages.tpl' type='info' content=$K10rStagingNotice}
     </div>
 {/block}


### PR DESCRIPTION
By changing the width of the message and moving it to a fixed position in the bottom right I aim to make the message more unobtrusive. Currently it sometimes overlays important information in the shop's header (e.g. other error messages).